### PR TITLE
Update version of chacha dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0.74"
 serde_derive = "1.0.74"
 toml = "0.4.6"
 rand = "0.5.5"
-chacha = "0.1.0"
+chacha = "0.3.0"
 sha3 = "0.7.3"
 
 [profile.release]


### PR DESCRIPTION
Chacha versions earlier than 0.3.0 have a bug in which keystream longer than 256 gigabytes start to repeat. See https://github.com/PeterReid/chacha/issues/6 .